### PR TITLE
Add docker and PM2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+.vscode
+data
+logs
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# ===============================================
+# BUILDER
+# This step builds the project
+# ===============================================
+
+# use the latest nodeJS LTS
+FROM node:14 AS builder
+
+# create the project directory
+WORKDIR /usr/src/infominer
+
+# copy all of the project files
+COPY . .
+
+# install and build the project
+RUN npm install
+RUN npm run build
+
+# ===============================================
+# PRODUCTION
+# This state prepares the project for production
+# ===============================================
+
+# use the latest nodeJS LTS
+FROM node:14
+
+# create the project directory
+WORKDIR /usr/src/infominer
+
+# copy the project package; used to run commands
+COPY package*.json ./
+# install the dependencies (only those used in production)
+RUN npm install --production
+
+# install PM2
+RUN npm install pm2 -g
+# copy PM2 configuration
+COPY ecosystem.config.yml ./
+
+# copy the built project from the 'builder' step
+COPY --from=builder /usr/src/infominer/dist ./dist
+
+# expose the port
+EXPOSE 8100
+# start the PM2 process and the service
+CMD ["pm2-runtime", "start", "ecosystem.config.yml"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The (semi-)automatic data exploration and topic ontology creation tool.
 
 -   **Create the `.env` file in the [./env][env] folder and configure it accordingly**
 
-    **NOTE:** If one setup the postgres docker container make sure to use the `TARGET` port
+    **NOTE:** If one setup the postgres docker container make sure to use the **TARGET** port
     (see [Database Configuration](#database-configuration)).
 
 ## Database Configuration
@@ -30,7 +30,7 @@ This repository contains the code used to create the infominer database.
 While the advised approach is to create a [postgres docker container][postgres-docker],
 one can set up and install the [postgres database][postgres-manual].
 
--   **(optional) Start the postgres docker container**
+1.  **(optional) Start the postgres docker container**
 
     -   Navigate into the docker folder
 
@@ -40,12 +40,12 @@ one can set up and install the [postgres database][postgres-manual].
 
     -   Modify the following fields in [docker-compose.yml][docker-compose]:
 
-        -   `POSTGRES_PASSWORD`: make sure it is secure
+        -   **POSTGRES_PASSWORD**: make sure it is secure
 
-        -   (optional) `ports`: This value sets the mapping/tunnel between the container and system.
-            The format is `TARGET:CONTAINER` where `TARGET` is the port number of the system which
-            is redirected to the containers port number `CONTAINER`. This will enable the user to
-            access the database through the `TARGET` port. If required, modify the `TARGET` port number,
+        -   (optional) **ports**: This value sets the mapping/tunnel between the container and system.
+            The format is `TARGET:CONTAINER` where **TARGET** is the port number of the system which
+            is redirected to the containers port number **CONTAINER**. This will enable the user to
+            access the database through the **TARGET** port. If required, modify the **TARGET** port number,
             i.e. `4110`.
 
     -   Start the containers:
@@ -81,8 +81,8 @@ one can set up and install the [postgres database][postgres-manual].
         ```
 
     **Data Persistence.** The data stored in the postgres database via docker will be persistent.
-    The `volumes` configuration are setup so that the database is stored in one of the volumes
-    found in `/var/lib/docker/volumes` folder (in this case it will be named `docker_infominer_db-data`).
+    The **volumes** configuration are setup so that the database is stored in one of the volumes
+    found in **/var/lib/docker/volumes** folder (in this case it will be named `docker_infominer-db`).
     If one would stop the container and run it again it will take the data found in the defined
     volume.
 
@@ -110,7 +110,7 @@ one can set up and install the [postgres database][postgres-manual].
         sudo docker volume rm docker_infominer-db
         ```
 
--   **Initialize the database tables.** To initialize the table one must simply run the following command:
+2.  **Initialize the database tables.** To initialize the table one must simply run the following command:
 
     ```bash
     node ./load/upgrade
@@ -119,7 +119,7 @@ one can set up and install the [postgres database][postgres-manual].
     This will create the required infominer tables. The table definitions are defined in files found in
     the [./load/postgres][postgres-defs] folder.
 
--   **Downgrading the database tables.** To remove all of the database tables simply run the following
+3.  **Downgrading the database tables.** To remove all of the database tables simply run the following
     command:
 
     ```bash
@@ -198,9 +198,9 @@ To dockerize infominer one can simply run the following command:
 npm run dockerize
 ```
 
-This will create a docker image `eriknovak/infominer-backend`. To make your own image, change the
-username part of the image name in `package.json`, e.g. `{username}/infominer-backend` of the
-`dockerize` script command.
+This will create a docker image **eriknovak/infominer-backend**. To make your own image, change the
+username part of the image name in `package.json`, e.g. **{username}/infominer-backend** of the
+**dockerize** script command.
 
 ## Start the container using `docker run`
 
@@ -224,17 +224,17 @@ docker run \
 The above command sets the port mapping, assigns the network in which the docker container will run in and provide
 environmental variables to infominer. Lets dissect the above command.
 
-| command part | command value               | description                                                                      |
-| ------------ | --------------------------- | -------------------------------------------------------------------------------- |
-| `-p`         | 8100:8100                   | The `TARGET:CONTAINER` port mapping                                              |
-| `--name`     | infominer-backend           | Name of the container to be run. Used to access it instead of its `CONTAINER ID` |
-| `--network`  | docker_infominer            | The network on which it runs. Same as `infominer-db` (see above).                |
-| `-e`         | PG_HOST=infominer-db        | ENV. The PG host is the container name.                                          |
-| `-e`         | PG_PORT=5432                | ENV. The PG port on which it is listening.                                       |
-| `-e`         | PG_USER=postgres            | ENV. The PG user that will access the database.                                  |
-| `-e`         | PG_PASSWORD=password        | ENV. The PG user password.                                                       |
-| `-e`         | PG_DATABASE=infominer       | ENV. The PG database.                                                            |
-| `-d`         | eriknovak/infominer-backend | Run the container in detach mode (running in the background).                    |
+| command part | command value               | description                                                                        |
+| ------------ | --------------------------- | ---------------------------------------------------------------------------------- |
+| `-p`         | 8100:8100                   | The **TARGET:CONTAINER** port mapping                                              |
+| `--name`     | infominer-backend           | Name of the container to be run. Used to access it instead of its **CONTAINER ID** |
+| `--network`  | docker_infominer            | The network on which it runs. Same as **infominer-db** (see above).                |
+| `-e`         | PG_HOST=infominer-db        | ENV. The PG host is the container name.                                            |
+| `-e`         | PG_PORT=5432                | ENV. The PG port on which it is listening.                                         |
+| `-e`         | PG_USER=postgres            | ENV. The PG user that will access the database.                                    |
+| `-e`         | PG_PASSWORD=password        | ENV. The PG user password.                                                         |
+| `-e`         | PG_DATABASE=infominer       | ENV. The PG database.                                                              |
+| `-d`         | eriknovak/infominer-backend | Run the container in detach mode (running in the background).                      |
 
 ## Start the container using `docker-compose`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The (semi-)automatic data exploration and topic ontology creation tool.
 -   **Create the `.env` file in the [./env][env] folder and configure it accordingly**
 
     **NOTE:** If one setup the postgres docker container make sure to use the `TARGET` port
-    (see Database Configuration).
+    (see [Database Configuration](#database-configuration)).
 
 ## Database Configuration
 
@@ -64,7 +64,7 @@ one can set up and install the [postgres database][postgres-manual].
 
         ```bash
         CONTAINER ID  IMAGE        COMMAND                 CREATED        STATUS        PORTS                   NAMES
-        52ac627f9966  postgres:13  "docker-entrypoint.s…"  5 seconds ago  Up 4 seconds  0.0.0.0:4110->5432/tcp  docker_infominer_db_1
+        52ac627f9966  postgres:13  "docker-entrypoint.s…"  5 seconds ago  Up 4 seconds  0.0.0.0:4110->5432/tcp  infominer-db
         ```
 
     -   (bonus) Stop the containers. This will stop all of the docker containers that are specified in
@@ -99,15 +99,15 @@ one can set up and install the [postgres database][postgres-manual].
 
         ```bash
         DRIVER  VOLUME NAME
-        local   docker_infominer_db-data
+        local   docker_infominer-db
         ```
 
-        The infominer database is named `docker_infominer_db-data`.
+        The infominer database is named `docker_infominer-db`.
 
     2. **Delete the docker volume.** To remove the volume run:
 
         ```bash
-        sudo docker volume rm docker_infominer_db-data
+        sudo docker volume rm docker_infominer-db
         ```
 
 -   **Initialize the database tables.** To initialize the table one must simply run the following command:
@@ -170,8 +170,79 @@ npm run clean
 
 **NOTE:** This will make the project as if no-one ever used it.
 
+## PM2
+
+To run Infominer in a more production setting one can use [PM2][pm2], a NodeJS process manager. To install
+it simply run
+
+```bash
+# install PM2 as a global library
+npm install pm2 -g
+```
+
+Once the installation is complete, one can configure the [ecosystem.config.yml](./ecosystem.config.yml) file.
+Assuming that the project has been built (`npm run build`) one can run the infominer backend in production mode
+with the following command:
+
+```bash
+pm2 start ecosytem.config.yml
+```
+
+This will monitor the project.
+
+# Dockerize
+
+To dockerize infominer one can simply run the following command:
+
+```bash
+npm run dockerize
+```
+
+This will create a docker image `eriknovak/infominer-backend`. To make your own image, change the
+username part of the image name in `package.json`, e.g. `{username}/infominer-backend` of the
+`dockerize` script command.
+
+## Start the container using `docker run`
+
+One can manually run the generated docker image. Assuming
+the database is running on docker (see [Database Configuration](#database-configuration)), run the
+command in the terminal:
+
+```bash
+docker run \
+    -p 8100:8100 \
+    --name infominer-backend \
+    --network docker_infominer \
+    -e PG_HOST=infominer-db \
+    -e PG_PORT=5432 \
+    -e PG_USER=postgres \
+    -e PG_PASSWORD=password \
+    -e PG_DATABASE=infominer \
+    -d eriknovak/infominer-backend
+```
+
+The above command sets the port mapping, assigns the network in which the docker container will run in and provide
+environmental variables to infominer. Lets dissect the above command.
+
+| command part | command value               | description                                                                      |
+| ------------ | --------------------------- | -------------------------------------------------------------------------------- |
+| `-p`         | 8100:8100                   | The `TARGET:CONTAINER` port mapping                                              |
+| `--name`     | infominer-backend           | Name of the container to be run. Used to access it instead of its `CONTAINER ID` |
+| `--network`  | docker_infominer            | The network on which it runs. Same as `infominer-db` (see above).                |
+| `-e`         | PG_HOST=infominer-db        | ENV. The PG host is the container name.                                          |
+| `-e`         | PG_PORT=5432                | ENV. The PG port on which it is listening.                                       |
+| `-e`         | PG_USER=postgres            | ENV. The PG user that will access the database.                                  |
+| `-e`         | PG_PASSWORD=password        | ENV. The PG user password.                                                       |
+| `-e`         | PG_DATABASE=infominer       | ENV. The PG database.                                                            |
+| `-d`         | eriknovak/infominer-backend | Run the container in detach mode (running in the background).                    |
+
+## Start the container using `docker-compose`
+
+TODO: provide a description
+
 [postgres-docker]: https://hub.docker.com/_/postgres
 [postgres-manual]: https://www.postgresql.org/download/
 [docker-compose]: ./docker/docker-compose.yml
 [env]: ./env
 [postgres-defs]: ./load/postgres
+[pm2]: https://pm2.io/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.1"
 services:
   infominer_db:
     image: postgres:13
+    container_name: infominer-db
     restart: always
     environment:
       - POSTGRES_USER=postgres
@@ -11,7 +12,7 @@ services:
     ports:
       - "4110:5432"
     volumes:
-      - infominer_db-data:/var/lib/postgresql/data
+      - infominer-db:/var/lib/postgresql/data
     networks:
       infominer: {}
 
@@ -19,4 +20,4 @@ networks:
   infominer: {}
 
 volumes:
-  infominer_db-data:
+  infominer-db:

--- a/ecosystem.config.yml
+++ b/ecosystem.config.yml
@@ -1,0 +1,10 @@
+apps:
+    - script: "server.js"
+      name: "infominer-backend"
+      cwd: "./dist/"
+      args: "--DEV_MODE"
+      instances: "1"
+      exec_mode: "fork"
+      autorestart: true
+      max_restart: 20
+      watch: false

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
         "clean": "rm -rf ./data && rm -rf ./tmp && cd ./load && node downgrade && node upgrade",
         "start": "ts-node ./src/server.ts --DEV_MODE",
         "start:watch": "tsnd --respawn ./src/server.ts --DEV_MODE",
-        "build": "tsc --project .",
-        "postbuild": "cpy --cwd=src --parents '**/*.json' ../dist/",
+        "build": "./node_modules/.bin/tsc --project .",
+        "postbuild": "./node_modules/.bin/cpy --cwd=src --parents '**/*.json' ../dist/",
         "deploy": "npm run build && node ./dist/server.js",
         "test": "echo \"Error: no test specified\" && exit 0",
-        "lint": "eslint './src/**/*.{js,ts}' --quiet --fix"
+        "lint": "eslint './src/**/*.{js,ts}' --quiet --fix",
+        "dockerize": "docker build -t eriknovak/infominer-backend ."
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR contains the files, modifications and documentation to run Infominer as a docker container. In addition, it contains the PM2 configurations used both for manual starting of the system as well as in the docker container.

Relevant Issues: #6.